### PR TITLE
feat : add simple demo script

### DIFF
--- a/examples/simple_demo.py
+++ b/examples/simple_demo.py
@@ -1,0 +1,72 @@
+"""
+Simple one-click demo for ScenarioNet / Traffic_automation.
+
+- Creates a small procedural (PG) demo database if it does not exist
+- Replays scenarios in MetaDrive using scenarionet.sim
+
+Run from repo root as:
+    python examples/simple_demo.py
+"""
+
+import sys
+import subprocess
+from pathlib import Path
+
+
+def run_cmd(cmd):
+    """Run a subprocess command and stream its output."""
+    print("\n>> Running:", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"\n❌ Command failed with exit code {e.returncode}")
+        sys.exit(e.returncode)
+
+
+def main():
+    # Repo root = parent of this file's directory
+    repo_root = Path(__file__).resolve().parents[1]
+
+    # Where we will store demo data
+    demo_root = repo_root / "demo_data"
+    demo_db = demo_root / "pg_demo_db"
+
+    demo_root.mkdir(exist_ok=True)
+
+    # 1. Create a small procedural-generation (PG) database if needed
+    if not demo_db.exists():
+        print(f"Creating demo database at: {demo_db}")
+
+        cmd_convert = [
+            sys.executable,
+            "-m",
+            "scenarionet.convert_pg",
+            "--database_path",
+            str(demo_db),
+            "--dataset_name",
+            "pg_demo",
+            "--num_scenarios",
+            "5",
+        ]
+        run_cmd(cmd_convert)
+    else:
+        print(f"Using existing demo database at: {demo_db}")
+
+    # 2. Run simulation using scenarionet.sim (2D render for lighter demo)
+    print("\nStarting simulation demo...")
+    cmd_sim = [
+        sys.executable,
+        "-m",
+        "scenarionet.sim",
+        "--database_path",
+        str(demo_db),
+        "--render",
+        "2D",
+    ]
+    run_cmd(cmd_sim)
+
+    print("\n✅ Demo finished. You can re-run `python examples/simple_demo.py` any time.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tutorial/read_established_scenarionet_dataset.ipynb
+++ b/tutorial/read_established_scenarionet_dataset.ipynb
@@ -71,11 +71,14 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pygame 2.5.2 (SDL 2.28.2, Python 3.9.18)\n",
-      "Hello from the pygame community. https://www.pygame.org/contribute.html\n"
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'pygame'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mModuleNotFoundError\u001b[39m                       Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# visualization\u001b[39;00m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mIPython\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mdisplay\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m Image \u001b[38;5;28;01mas\u001b[39;00m IImage\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpygame\u001b[39;00m\n\u001b[32m      4\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mnumpy\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mnp\u001b[39;00m\n\u001b[32m      5\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mPIL\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m Image\n",
+      "\u001b[31mModuleNotFoundError\u001b[39m: No module named 'pygame'"
      ]
     }
    ],
@@ -232,8 +235,8 @@
     {
      "data": {
       "text/plain": [
-       "\u001B[0;31mSignature:\u001B[0m \u001B[0mread_dataset_summary\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mdataset_path\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
-       "\u001B[0;31mDocstring:\u001B[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mread_dataset_summary\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset_path\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
        "Read the dataset and return the metadata of each scenario in this dataset.\n",
        "\n",
        "Args:\n",
@@ -244,8 +247,8 @@
        "    1) the summary dict mapping from scenario ID to its metadata,\n",
        "    2) the list of all scenarios IDs, and\n",
        "    3) a dict mapping from scenario IDs to the folder that hosts their files.\n",
-       "\u001B[0;31mFile:\u001B[0m      ~/scenarionet/scenarionet/common_utils.py\n",
-       "\u001B[0;31mType:\u001B[0m      function"
+       "\u001b[0;31mFile:\u001b[0m      ~/scenarionet/scenarionet/common_utils.py\n",
+       "\u001b[0;31mType:\u001b[0m      function"
       ]
      },
      "metadata": {},
@@ -3593,8 +3596,8 @@
     {
      "data": {
       "text/plain": [
-       "\u001B[0;31mSignature:\u001B[0m \u001B[0mread_scenario\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mdataset_path\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mmapping\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mscenario_file_name\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
-       "\u001B[0;31mDocstring:\u001B[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mread_scenario\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmapping\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mscenario_file_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
        "Read a scenario pkl file and return the Scenario Description instance.\n",
        "\n",
        "Args:\n",
@@ -3604,8 +3607,8 @@
        "\n",
        "Returns:\n",
        "    The Scenario Description instance of that scenario.\n",
-       "\u001B[0;31mFile:\u001B[0m      ~/scenarionet/scenarionet/common_utils.py\n",
-       "\u001B[0;31mType:\u001B[0m      function"
+       "\u001b[0;31mFile:\u001b[0m      ~/scenarionet/scenarionet/common_utils.py\n",
+       "\u001b[0;31mType:\u001b[0m      function"
       ]
      },
      "metadata": {},
@@ -3706,7 +3709,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What changes did I make in this PR?
This PR adds a beginner-friendly one-click simulation demo (examples/simple_demo.py) to help new users quickly run ScenarioNet without navigating the full pipeline.

The script automatically:
- Creates a small procedural traffic scenario database using scenarionet.convert_pg (if it does not already exist)
- Runs a lightweight simulation in 2D using scenarionet.sim
- Prints clear console messages to guide users through the process

This contribution improves accessibility for first-time users and provides an immediate way to verify installation, run scenarios, and understand the project workflow without additional setup.

## Why I created this PR

Many new users struggle to run an initial scenario or understand how the conversion/simulation pipeline connects.
This demo offers:

- An easy entry point.
- A runnable example with minimal configuration.
- A quick validation that ScenarioNet and MetaDrive are installed correctly.

It enhances onboarding and lowers the barrier for experimentation and development.

## Checklist

- [ ] I have merged the latest main branch into the current branch.
- [ ]  I have run bash scripts/format.sh before merging.
- [ ]  I updated documentation, if there are related changes.
- [ ]  I added tests if there are new functions or bug fixes.

Please use "squash and merge" mode.
