### PR TITLE
Fix(check_overlap): correct variable names for argparse arguments

### DIFF
--- a/scenarionet/check_overlap.py
+++ b/scenarionet/check_overlap.py
@@ -16,8 +16,8 @@ if __name__ == '__main__':
     parser.add_argument('--show_id', action="store_true", help="whether to show the id of overlapped scenarios")
     args = parser.parse_args()
 
-    summary_1, _, _ = read_dataset_summary(args.database_1)
-    summary_2, _, _ = read_dataset_summary(args.database_2)
+    summary_1, _, _ = read_dataset_summary(args.d_1)
+    summary_2, _, _ = read_dataset_summary(args.d_2)
 
     intersection = set(summary_1.keys()).intersection(set(summary_2.keys()))
     if len(intersection) == 0:


### PR DESCRIPTION
## What changes do you make in this PR?

The argparse arguments were defined as `--d_1` and `--d_2`, but the script
incorrectly attempted to access them via `args.database_1` and `args.database_2`, causing an AttributeError. This commit updates the variable references to`args.d_1` and `args.d_2` to match the parsed arguments.

## Checklist

* [x] I have merged the latest main branch into current branch.
* [x] I have run `bash scripts/format.sh` before merging.
* [x] I updated documentation, if there are related change
* [x] I add tests if there are new functions or bug-fixing
